### PR TITLE
feature: flag to create or not the route 53 validation record

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 [![Lint Status](https://github.com/DNXLabs/terraform-aws-acm-certificate/workflows/Lint/badge.svg)](https://github.com/DNXLabs/terraform-aws-acm-certificate/actions)
 [![LICENSE](https://img.shields.io/github/license/DNXLabs/terraform-aws-acm-certificate)](https://github.com/DNXLabs/terraform-aws-acm-certificate/blob/master/LICENSE)
 
+
+## Usage
+
+```hcl
+module "acm_certificate" {
+  source = "git::https://github.com/DNXLabs/terraform-aws-acm-certificate?ref=0.2.2"
+
+  domain_names             = ["example.com", "*.example.com"]
+  validation_method        = "DNS"
+  create_validation_record = false
+}
+```
+
 <!--- BEGIN_TF_DOCS --->
 
 ## Requirements

--- a/_variables.tf
+++ b/_variables.tf
@@ -11,3 +11,9 @@ variable "hosted_zone_id" {
   description = "Route53 hosted zone to create validation records. For use when validation_method is DNS. Leave it blank to validate manually."
   default     = ""
 }
+
+variable "create_validation_record" {
+  description = "Flag to whether create or not the Route 53 validation record"
+  type        = bool
+  default     = true
+}

--- a/route53.tf
+++ b/route53.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-    if var.validation_method == "DNS"
+    if var.validation_method == "DNS" && var.create_validation_record
   }
 
   allow_overwrite = true


### PR DESCRIPTION
This PR adds a flag to whether create or not the Route 53 validation record. This is useful when you want to validate the ACM certificate by DNS, but the hosted zone resides in a different account from the running Terraform workspace.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
